### PR TITLE
📝 docs: comprehensive Rustdoc, examples, metadata, and release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This project adheres to Keep a Changelog and uses Semantic Versioning.
+
+## [Unreleased]
+
+### Added
+- Comprehensive rustdoc across the sleep-api crate:
+  - Crate-level docs with overview, example, and links to OpenAPI and API examples (C-EXAMPLE, C-LINK).
+  - Module docs for app, config, db, domain, models, repository, time, trends, and views.
+  - Item-level docs for public types and functions with “why-driven” examples that use the `?` operator (C-EXAMPLE, C-QUESTION-MARK).
+  - Error sections on fallible functions, documenting expected error variants (C-FAILURE).
+  - DST-aware behavior explained for time::compute_duration_min with example (C-EXAMPLE).
+- Cargo metadata fields in sleep-api/Cargo.toml (authors, description, license, repository, keywords, categories) (C-METADATA).
+- Link to Release Notes from crate-level documentation (C-RELNOTES).
+
+### Changed
+- trends_page error handling to log template rendering errors and avoid unwraps in application code.
+- Intra-doc links added between related items (e.g., models ↔ repository ↔ time) (C-LINK).
+
+### Hidden
+- Marked impl From<DomainError> for ApiError as #[doc(hidden)] to avoid surfacing non-actionable internals in public docs (C-HIDDEN).
+
+### Notes
+- Doc examples that interact with the database are marked as `no_run` and use hidden setup lines to compile but avoid external effects. All examples prefer `?` over unwrap/try! (C-QUESTION-MARK).
+- Ensure CI runs `cargo doc` and `cargo test --doc` with rustdoc link lints enabled for ongoing quality.
+
+## [0.1.0] - 2025-08-11
+### Added
+- Initial SleepTracker API crate structure (Axum router, SQLx repository, models, time utilities).
+- Basic routes and trends endpoints.
+- Initial migrations and OpenAPI spec.

--- a/sleep-api/Cargo.toml
+++ b/sleep-api/Cargo.toml
@@ -2,6 +2,12 @@
 name = "sleep-api"
 version = "0.1.0"
 edition = "2024"
+description = "SleepTracker API components: Axum router, models, SQLx repository, and DST-aware time helpers."
+license = "MIT"
+repository = "https://github.com/ebigunso/SleepTracker"
+authors = ["ebigunso"]
+keywords = ["sleep", "axum", "sqlx", "sqlite", "api"]
+categories = ["web-programming::http-server", "database", "api-bindings"]
 
 [dependencies]
 axum = "0.8.4"

--- a/sleep-api/src/app.rs
+++ b/sleep-api/src/app.rs
@@ -1,3 +1,16 @@
+#![doc = r#"HTTP routing
+
+Defines the Axum [`Router`] that exposes the SleepTracker API. This module wires
+all HTTP routes (health check, sleep CRUD, exercise, notes, and trends).
+
+See the OpenAPI specification for request/response details:
+- <https://github.com/ebigunso/SleepTracker/blob/main/openapi.yaml>
+
+For an end-to-end server setup example, see [`router`].
+
+[`Router`]: axum::Router
+"#]
+
 use crate::{
     db::Db,
     error::ApiError,
@@ -15,6 +28,37 @@ use axum::{
 };
 use serde_json::json;
 
+#[doc = r#"Build the application [`Router`].
+
+Routes:
+- `GET /health`
+- `POST /sleep`
+- `GET /sleep/date/{date}`
+- `PUT /sleep/{id}`
+- `DELETE /sleep/{id}`
+- `POST /exercise`
+- `POST /note`
+- `GET /api/trends/sleep-bars`
+- `GET /api/trends/summary`
+- `GET /trends`
+
+# Example
+
+```rust,no_run
+# use std::error::Error;
+# async fn demo() -> Result<(), Box<dyn Error>> {
+# // Acquire a database connection pool (for demonstration only).
+let db = sleep_api::db::connect().await?;
+let app = sleep_api::app::router(db);
+
+// Now serve `app` with Axum/Hyper (listener creation elided).
+// hyper::Server::bind(&addr).serve(app.into_make_service()).await?;
+# Ok(())
+# }
+```
+
+[`Router`]: axum::Router
+"#]
 pub fn router(db: Db) -> Router {
     Router::new()
         .route("/health", get(|| async { Json(json!({"status":"ok"})) }))

--- a/sleep-api/src/config.rs
+++ b/sleep-api/src/config.rs
@@ -18,9 +18,10 @@ bed/wake times in a consistent, DST-aware manner.
 
 # Example
 
-```rust
+```rust,no_run
 # use std::error::Error;
 # fn main() -> Result<(), Box<dyn Error>> {
+# unsafe {
 std::env::set_var("APP_TZ", "Asia/Tokyo");
 let tz = sleep_api::config::app_tz();
 assert_eq!(tz, chrono_tz::Asia::Tokyo);
@@ -29,6 +30,7 @@ assert_eq!(tz, chrono_tz::Asia::Tokyo);
 std::env::set_var("APP_TZ", "Not/AZone");
 let tz2 = sleep_api::config::app_tz();
 assert_eq!(tz2, chrono_tz::Asia::Tokyo);
+# }
 # Ok(()) }
 ```
 

--- a/sleep-api/src/config.rs
+++ b/sleep-api/src/config.rs
@@ -1,8 +1,39 @@
+#![doc = r#"Configuration utilities
+
+Provides application configuration helpers such as the default timezone used by
+time computations. See also: [`time::compute_duration_min`].
+
+[`time::compute_duration_min`]: crate::time::compute_duration_min
+"#]
+
 use chrono_tz::Tz;
 use std::str::FromStr;
 
-/// Returns the application timezone from APP_TZ or defaults to Asia/Tokyo.
-/// Falls back to Asia/Tokyo if an unknown TZ name is provided.
+#[doc = r#"Return the application timezone derived from the `APP_TZ` environment variable.
+
+If `APP_TZ` is not set or contains an unknown zone name, the function falls back to `Asia/Tokyo`.
+
+This timezone is used by functions like [`time::compute_duration_min`] to interpret local
+bed/wake times in a consistent, DST-aware manner.
+
+# Example
+
+```rust
+# use std::error::Error;
+# fn main() -> Result<(), Box<dyn Error>> {
+std::env::set_var("APP_TZ", "Asia/Tokyo");
+let tz = sleep_api::config::app_tz();
+assert_eq!(tz, chrono_tz::Asia::Tokyo);
+
+// Unknown values also fall back to Asia/Tokyo.
+std::env::set_var("APP_TZ", "Not/AZone");
+let tz2 = sleep_api::config::app_tz();
+assert_eq!(tz2, chrono_tz::Asia::Tokyo);
+# Ok(()) }
+```
+
+[`time::compute_duration_min`]: crate::time::compute_duration_min
+"#]
 pub fn app_tz() -> Tz {
     let name = std::env::var("APP_TZ").unwrap_or_else(|_| "Asia/Tokyo".to_string());
     Tz::from_str(&name).unwrap_or(chrono_tz::Asia::Tokyo)

--- a/sleep-api/src/db.rs
+++ b/sleep-api/src/db.rs
@@ -1,7 +1,42 @@
+#![doc = r#"Database utilities
+
+Provides the shared Sqlite connection pool type [`Db`] and a helper to connect
+and enforce SQLite foreign key constraints.
+
+[`Db`]: crate::db::Db
+"#]
+
 use sqlx::{Pool, Sqlite, sqlite::SqlitePoolOptions};
 
+/// Pooled Sqlite connection handle used by the application.
+///
+/// This is a type alias for [`sqlx::Pool<sqlx::Sqlite>`].
 pub type Db = Pool<Sqlite>;
 
+#[doc = r#"Connect to the database and enable SQLite foreign keys (`PRAGMA foreign_keys = ON`).
+
+Reads the `DATABASE_URL` environment variable (e.g., `sqlite::memory:` or a file path),
+establishes a connection pool, and enables foreign key constraints.
+
+# Example
+```rust,no_run
+# use std::error::Error;
+# async fn demo() -> Result<(), Box<dyn Error>> {
+// Use an in-memory database for demonstration.
+std::env::set_var("DATABASE_URL", "sqlite::memory:");
+let db = sleep_api::db::connect().await?;
+
+// Simple sanity query
+sqlx::query("SELECT 1").execute(&db).await?;
+# Ok(()) }
+```
+
+# Errors
+- Returns [`sqlx::Error::Configuration`] if `DATABASE_URL` is missing.
+- Returns other [`sqlx::Error`] variants if the connection or PRAGMA execution fails.
+
+[`sqlx::Error::Configuration`]: sqlx::Error
+"#]
 pub async fn connect() -> Result<Db, sqlx::Error> {
     dotenvy::dotenv().ok();
     use std::io;

--- a/sleep-api/src/db.rs
+++ b/sleep-api/src/db.rs
@@ -23,7 +23,7 @@ establishes a connection pool, and enables foreign key constraints.
 # use std::error::Error;
 # async fn demo() -> Result<(), Box<dyn Error>> {
 // Use an in-memory database for demonstration.
-std::env::set_var("DATABASE_URL", "sqlite::memory:");
+# // DATABASE_URL should be configured in the environment for this example.
 let db = sleep_api::db::connect().await?;
 
 // Simple sanity query

--- a/sleep-api/src/domain.rs
+++ b/sleep-api/src/domain.rs
@@ -1,5 +1,38 @@
+#![doc = r#"Domain model and error types
+
+Contains the error type used for validating inputs and enforcing invariants across
+the crate. Errors from this module are propagated by many functions using the `?`
+operator. See [`time::compute_duration_min`] and [`models::sleep::SleepInput::validate`].
+
+[`time::compute_duration_min`]: crate::time::compute_duration_min
+[`models::sleep::SleepInput::validate`]: crate::models::sleep::SleepInput::validate
+"#]
+
 use thiserror::Error;
 
+#[doc = r#"Domain-level error type.
+
+Variants:
+- `InvalidIntensity(String)`: Parsing or validation failure for exercise intensity.
+- `InvalidQuality`: Sleep quality must be in the 1..=5 range.
+- `InvalidInput(String)`: Generic validation failure, e.g. invalid ranges or non-positive duration.
+
+# Example (propagating with ?)
+
+```rust
+# use chrono::{NaiveDate, NaiveTime};
+# use chrono_tz::Asia::Tokyo;
+# fn main() -> Result<(), sleep_api::domain::DomainError> {
+let mins = sleep_api::time::compute_duration_min(
+    NaiveDate::from_ymd_opt(2025, 6, 1).ok_or_else(|| sleep_api::domain::DomainError::InvalidInput("invalid date".into()))?,
+    NaiveTime::from_hms_opt(22, 30, 0).ok_or_else(|| sleep_api::domain::DomainError::InvalidInput("invalid time".into()))?,
+    NaiveTime::from_hms_opt(6, 30, 0).ok_or_else(|| sleep_api::domain::DomainError::InvalidInput("invalid time".into()))?,
+    Tokyo,
+)?;
+assert!(mins > 0);
+# Ok(()) }
+```
+"#]
 #[derive(Debug, Error)]
 #[allow(clippy::enum_variant_names)]
 pub enum DomainError {

--- a/sleep-api/src/error.rs
+++ b/sleep-api/src/error.rs
@@ -41,6 +41,7 @@ impl IntoResponse for ApiError {
     }
 }
 
+#[doc(hidden)]
 impl From<DomainError> for ApiError {
     fn from(err: DomainError) -> Self {
         ApiError::InvalidInput(err.to_string())

--- a/sleep-api/src/lib.rs
+++ b/sleep-api/src/lib.rs
@@ -1,3 +1,49 @@
+#![doc = r#"
+SleepTracker API library
+
+This crate provides the building blocks of a small sleep‑tracking API built with Axum and SQLx.
+It exposes modules for HTTP routing, persistence, domain models and time handling.
+
+Key modules:
+- [`app`] — HTTP router wiring all routes.
+- [`db`] — database pool and connection utilities.
+- [`models`] — input/output types with validation.
+- [`repository`] — persistence operations.
+- [`time`] — time and duration helpers including DST‑aware computations.
+- [`trends`] and [`views`] — aggregation endpoints and templates.
+
+Why: use this crate to embed the API server in your binary, or reuse its types and helpers like [`compute_duration_min`].
+
+# Example
+
+Bootstrapping a Router:
+
+```rust,no_run
+# use std::error::Error;
+# async fn demo() -> Result<(), Box<dyn Error>> {
+let db = sleep_api::db::connect().await?;
+let app = sleep_api::app::router(db);
+// axum::serve(listener, app).await?;
+# Ok(())
+# }
+```
+
+Additional references:
+- OpenAPI specification: https://github.com/ebigunso/SleepTracker/blob/main/openapi.yaml
+- API examples: https://github.com/ebigunso/SleepTracker/blob/main/docs/api_examples.md
+
+See also: [`time`], [`repository`], and [`models`].
+
+[`app`]: crate::app
+[`db`]: crate::db
+[`models`]: crate::models
+[`repository`]: crate::repository
+[`time`]: crate::time
+[`trends`]: crate::trends
+[`views`]: crate::views
+[`compute_duration_min`]: crate::time::compute_duration_min
+"#]
+
 pub mod app;
 pub mod config;
 pub mod db;

--- a/sleep-api/src/lib.rs
+++ b/sleep-api/src/lib.rs
@@ -31,6 +31,7 @@ let app = sleep_api::app::router(db);
 Additional references:
 - OpenAPI specification: https://github.com/ebigunso/SleepTracker/blob/main/openapi.yaml
 - API examples: https://github.com/ebigunso/SleepTracker/blob/main/docs/api_examples.md
+- Release notes: https://github.com/ebigunso/SleepTracker/blob/main/CHANGELOG.md
 
 See also: [`time`], [`repository`], and [`models`].
 

--- a/sleep-api/src/models/exercise.rs
+++ b/sleep-api/src/models/exercise.rs
@@ -3,6 +3,33 @@ use crate::domain::DomainError;
 use chrono::{NaiveDate, NaiveTime};
 use serde::{Deserialize, Serialize};
 
+#[doc = r#"User-provided input representing an exercise event.
+
+Fields:
+- `date`: calendar date of the exercise.
+- `intensity`: qualitative intensity level, see [`Intensity`].
+- `start_time`: optional local start time.
+- `duration_min`: optional duration in minutes.
+
+# Example
+
+```rust
+# use sleep_api::domain::DomainError;
+# use sleep_api::models::{ExerciseInput, Intensity};
+# use chrono::{NaiveDate, NaiveTime};
+# fn main() -> Result<(), DomainError> {
+let ex = ExerciseInput {
+    date: NaiveDate::from_ymd_opt(2025, 6, 1).ok_or_else(|| DomainError::InvalidInput("invalid date".into()))?,
+    intensity: Intensity::Light,
+    start_time: Some(NaiveTime::from_hms_opt(18, 30, 0).ok_or_else(|| DomainError::InvalidInput("invalid time".into()))?),
+    duration_min: Some(45),
+};
+ex.validate()?;
+# Ok(()) }
+```
+
+[`Intensity`]: crate::models::Intensity
+"#]
 #[derive(Serialize, Deserialize, Clone)]
 pub struct ExerciseInput {
     pub date: NaiveDate,
@@ -12,6 +39,15 @@ pub struct ExerciseInput {
 }
 
 impl ExerciseInput {
+    #[doc = r#"Validate the exercise input.
+
+Currently, this ensures that `intensity` has been deserialized into a valid value.
+Add additional checks here as needed (e.g., maximum duration).
+
+# Errors
+
+Returns [`DomainError`] if a validation rule is violated (none at present).
+"#]
     pub fn validate(&self) -> Result<(), DomainError> {
         // intensity is validated by deserialization
         Ok(())

--- a/sleep-api/src/models/intensity.rs
+++ b/sleep-api/src/models/intensity.rs
@@ -1,8 +1,41 @@
+#![doc = r#"Exercise intensity levels
+
+Represents qualitative intensity used by the exercise model. Values serialize as lowercase
+strings and implement both `Display` and `FromStr` for ergonomic use.
+
+- Serde representation: `"none" | "light" | "hard"`.
+- `Display`: prints the lowercase string.
+- `FromStr`: parses the lowercase string and returns a [`DomainError::InvalidIntensity`] on failure.
+
+[`DomainError::InvalidIntensity`]: crate::domain::DomainError::InvalidIntensity
+"#]
+
 use crate::domain::DomainError;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[doc = r#"Exercise intensity level.
+
+# Example
+
+```rust
+# use sleep_api::domain::DomainError;
+# fn main() -> Result<(), DomainError> {
+use sleep_api::models::Intensity;
+
+let level: Intensity = "light".parse()?;
+assert_eq!(level.to_string(), "light");
+# Ok(()) }
+```
+
+# Errors
+
+Parsing with `FromStr` returns [`DomainError::InvalidIntensity`] when the input is not one of:
+`"none"`, `"light"`, or `"hard"`.
+
+[`DomainError::InvalidIntensity`]: crate::domain::DomainError::InvalidIntensity
+"#]
 pub enum Intensity {
     None,
     Light,

--- a/sleep-api/src/models/mod.rs
+++ b/sleep-api/src/models/mod.rs
@@ -1,3 +1,14 @@
+#![doc = r#"Data models
+
+Structures and enums used as request/response payloads and DB projections.
+
+Key types: [`SleepInput`], [`SleepSession`], [`ExerciseInput`], [`NoteInput`], [`Quality`], [`Intensity`].
+
+See also: [`repository`] for persistence operations and [`time::compute_duration_min`] for DST-aware duration computation.
+
+[`repository`]: crate::repository
+"#]
+
 pub mod exercise;
 pub mod intensity;
 pub mod note;

--- a/sleep-api/src/models/note.rs
+++ b/sleep-api/src/models/note.rs
@@ -2,6 +2,28 @@ use crate::domain::DomainError;
 use chrono::NaiveDate;
 use serde::{Deserialize, Serialize};
 
+#[doc = r#"User-provided note associated with a date.
+
+Notes can be used to capture free-form observations that may help interpret sleep data.
+
+- `date`: calendar date the note applies to.
+- `body`: optional free text. Limited to 1000 characters.
+
+# Example
+
+```rust
+# use sleep_api::domain::DomainError;
+# use sleep_api::models::NoteInput;
+# use chrono::NaiveDate;
+# fn main() -> Result<(), DomainError> {
+let note = NoteInput {
+    date: NaiveDate::from_ymd_opt(2025, 6, 1).ok_or_else(|| DomainError::InvalidInput("invalid date".into()))?,
+    body: Some("Felt refreshed".to_string()),
+};
+note.validate()?;
+# Ok(()) }
+```
+"#]
 #[derive(Serialize, Deserialize, Clone)]
 pub struct NoteInput {
     pub date: NaiveDate,
@@ -9,6 +31,14 @@ pub struct NoteInput {
 }
 
 impl NoteInput {
+    #[doc = r#"Validate the note length (<= 1000 characters).
+
+# Errors
+
+Returns [`DomainError::InvalidInput`] if `body` is longer than 1000 characters.
+
+[`DomainError::InvalidInput`]: crate::domain::DomainError::InvalidInput
+"#]
     pub fn validate(&self) -> Result<(), DomainError> {
         if let Some(ref b) = self.body
             && (b.len() > 1000)

--- a/sleep-api/src/models/quality.rs
+++ b/sleep-api/src/models/quality.rs
@@ -1,6 +1,27 @@
 use crate::domain::DomainError;
 use serde::{Deserialize, Deserializer, Serialize};
 
+#[doc = r#"Sleep quality score (1..=5).
+
+Semantic wrapper around `u8` validated during deserialization and conversion.
+Higher values indicate better perceived sleep quality.
+
+# Example
+
+```rust
+# use sleep_api::domain::DomainError;
+use sleep_api::models::Quality;
+
+// Construct directly
+let q = Quality(4);
+assert_eq!(q.value(), 4);
+
+// Fallible construction from raw value
+let q2 = Quality::try_from(5u8)?; // 1..=5 ok
+assert_eq!(q2.value(), 5);
+# Ok::<(), DomainError>(())
+```
+"#]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub struct Quality(pub u8);
 
@@ -19,11 +40,20 @@ impl<'de> Deserialize<'de> for Quality {
 }
 
 impl Quality {
+    #[doc = r#"Return the underlying 1..=5 score."#]
     pub fn value(self) -> u8 {
         self.0
     }
 }
 
+#[doc = r#"Attempt to convert a raw `u8` into a [`Quality`].
+
+# Errors
+
+Returns [`DomainError::InvalidQuality`] if the value is not in 1..=5.
+
+[`DomainError::InvalidQuality`]: crate::domain::DomainError::InvalidQuality
+"#]
 impl TryFrom<u8> for Quality {
     type Error = DomainError;
     fn try_from(v: u8) -> Result<Self, Self::Error> {

--- a/sleep-api/src/models/sleep.rs
+++ b/sleep-api/src/models/sleep.rs
@@ -85,7 +85,7 @@ This type aggregates fields from `sleep_sessions` and `sleep_metrics` for a give
 
 Note: `quality` is stored as `i32` in the DB layer; use [`Quality::try_from`] to convert into the strong type if needed.
 
-[`Quality::try_from`]: crate::models::Quality#impl-TryFrom%3Cu8%3E
+[`Quality::try_from`]: crate::models::Quality::try_from
 "#]
 #[derive(Serialize, Deserialize, Debug, PartialEq, FromRow)]
 pub struct SleepSession {

--- a/sleep-api/src/models/sleep.rs
+++ b/sleep-api/src/models/sleep.rs
@@ -4,6 +4,40 @@ use chrono::{NaiveDate, NaiveTime};
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 
+#[doc = r#"User-provided input for creating or updating a sleep session.
+
+Field semantics (wake-date model):
+- `date`: the wake date of the sleep (the morning date).
+- `bed_time` / `wake_time`: local times. If `bed_time > wake_time`, the bed datetime
+  is considered to be on the previous calendar day.
+- `latency_min`: minutes to fall asleep, must be in 0..=180.
+- `awakenings`: number of awakenings, must be in 0..=10.
+- `quality`: discrete quality score enforced by [`Quality`] (1..=5).
+
+For duration computations across DST, see [`compute_duration_min`].
+
+# Example
+
+```rust
+# use sleep_api::domain::DomainError;
+# use sleep_api::models::{SleepInput, Quality};
+# use chrono::{NaiveDate, NaiveTime};
+# fn main() -> Result<(), DomainError> {
+let input = SleepInput {
+    date: NaiveDate::from_ymd_opt(2025, 6, 1).ok_or_else(|| DomainError::InvalidInput("invalid date".into()))?,
+    bed_time: NaiveTime::from_hms_opt(23, 0, 0).ok_or_else(|| DomainError::InvalidInput("invalid time".into()))?,
+    wake_time: NaiveTime::from_hms_opt(7, 0, 0).ok_or_else(|| DomainError::InvalidInput("invalid time".into()))?,
+    latency_min: 10,
+    awakenings: 1,
+    quality: Quality(4),
+};
+input.validate()?;
+# Ok(()) }
+```
+
+[`compute_duration_min`]: crate::time::compute_duration_min
+[`Quality`]: crate::models::Quality
+"#]
 #[derive(Serialize, Deserialize, Clone)]
 pub struct SleepInput {
     pub date: NaiveDate,
@@ -15,6 +49,20 @@ pub struct SleepInput {
 }
 
 impl SleepInput {
+    #[doc = r#"Validate input ranges for latency and awakenings.
+
+- `latency_min` must be in 0..=180
+- `awakenings` must be in 0..=10
+- `quality` is validated by the [`Quality`] type
+- Time relationships are validated at duration computation time (see [`compute_duration_min`]).
+
+# Errors
+
+Returns [`DomainError::InvalidInput`] when a field is out of range.
+
+[`Quality`]: crate::models::Quality
+[`compute_duration_min`]: crate::time::compute_duration_min
+"#]
     pub fn validate(&self) -> Result<(), DomainError> {
         if !(0..=180).contains(&self.latency_min) {
             return Err(DomainError::InvalidInput(
@@ -31,6 +79,14 @@ impl SleepInput {
     }
 }
 
+#[doc = r#"Database projection of a stored sleep session.
+
+This type aggregates fields from `sleep_sessions` and `sleep_metrics` for a given session id.
+
+Note: `quality` is stored as `i32` in the DB layer; use [`Quality::try_from`] to convert into the strong type if needed.
+
+[`Quality::try_from`]: crate::models::Quality#impl-TryFrom%3Cu8%3E
+"#]
 #[derive(Serialize, Deserialize, Debug, PartialEq, FromRow)]
 pub struct SleepSession {
     pub id: i64,

--- a/sleep-api/src/repository.rs
+++ b/sleep-api/src/repository.rs
@@ -35,7 +35,7 @@ Pass a precomputed `duration_min` (see [`time::compute_duration_min`]).
 # use sleep_api::{db, repository, models::{SleepInput, Quality}};
 # use chrono::{NaiveDate, NaiveTime};
 # async fn demo() -> Result<(), Box<dyn Error>> {
-//// Ensure DATABASE_URL is set in the environment (e.g., sqlite::memory:).
+// Ensure DATABASE_URL is set in the environment (e.g., sqlite::memory:).
 let db = db::connect().await?;
 sqlx::migrate::Migrator::new(std::path::Path::new("../migrations")).await?.run(&db).await?;
 
@@ -172,7 +172,7 @@ pub async fn delete_sleep(db: &Db, id: i64) -> Result<u64, sqlx::Error> {
 # use sleep_api::{db, repository, models::{ExerciseInput, Intensity}};
 # use chrono::NaiveDate;
 # async fn demo() -> Result<(), Box<dyn Error>> {
-//// Ensure DATABASE_URL is set in the environment (e.g., sqlite::memory:).
+// Ensure DATABASE_URL is set in the environment (e.g., sqlite::memory:).
 let db = db::connect().await?;
 sqlx::migrate::Migrator::new(std::path::Path::new("../migrations")).await?.run(&db).await?;
 
@@ -217,7 +217,7 @@ A `None` body is stored as NULL.
 # use sleep_api::{db, repository, models::NoteInput};
 # use chrono::NaiveDate;
 # async fn demo() -> Result<(), Box<dyn Error>> {
-//// Ensure DATABASE_URL is set in the environment (e.g., sqlite::memory:).
+// Ensure DATABASE_URL is set in the environment (e.g., sqlite::memory:).
 let db = db::connect().await?;
 sqlx::migrate::Migrator::new(std::path::Path::new("../migrations")).await?.run(&db).await?;
 

--- a/sleep-api/src/repository.rs
+++ b/sleep-api/src/repository.rs
@@ -1,3 +1,20 @@
+#![doc = r#"Persistence layer
+
+Wraps SQLx statements for inserting, updating, fetching, and deleting domain records.
+Operations that touch multiple tables use a single transaction to keep data consistent.
+
+Why: prefer using these helpers over ad-hoc queries to ensure invariants and transactional correctness.
+
+See also:
+- [`models`] for data shapes
+- [`time::compute_duration_min`] for deriving duration values
+- Examples on [`insert_sleep`] demonstrating end-to-end usage.
+
+[`models`]: crate::models
+[`time::compute_duration_min`]: crate::time::compute_duration_min
+[`insert_sleep`]: crate::repository::insert_sleep
+"#]
+
 use crate::{
     db::Db,
     models::{ExerciseInput, NoteInput, SleepInput, SleepSession},
@@ -5,6 +22,42 @@ use crate::{
 use chrono::NaiveDate;
 use sqlx::{Sqlite, Transaction};
 
+#[doc = r#"Insert a sleep session and its metrics in a single transaction.
+
+The session row is written to `sleep_sessions` and the metrics to `sleep_metrics`.
+Pass a precomputed `duration_min` (see [`time::compute_duration_min`]).
+
+# Example
+
+```rust,no_run
+# use sleep_api::domain::DomainError;
+# use std::error::Error;
+# use sleep_api::{db, repository, models::{SleepInput, Quality}};
+# use chrono::{NaiveDate, NaiveTime};
+# async fn demo() -> Result<(), Box<dyn Error>> {
+std::env::set_var("DATABASE_URL", "sqlite::memory:");
+let db = db::connect().await?;
+sqlx::migrate::Migrator::new(std::path::Path::new("../migrations")).await?.run(&db).await?;
+
+let input = SleepInput {
+    date: NaiveDate::from_ymd_opt(2025, 6, 1).ok_or_else(|| DomainError::InvalidInput("invalid date".into()))?,
+    bed_time: NaiveTime::from_hms_opt(23, 0, 0).ok_or_else(|| DomainError::InvalidInput("invalid time".into()))?,
+    wake_time: NaiveTime::from_hms_opt(7, 0, 0).ok_or_else(|| DomainError::InvalidInput("invalid time".into()))?,
+    latency_min: 10,
+    awakenings: 1,
+    quality: Quality(4),
+};
+let tz = sleep_api::config::app_tz();
+let dur = sleep_api::time::compute_duration_min(input.date, input.bed_time, input.wake_time, tz)?;
+let id = repository::insert_sleep(&db, &input, dur).await?;
+# Ok(()) }
+```
+
+# Errors
+- Returns [`sqlx::Error`] on database connection or execution errors.
+
+[`time::compute_duration_min`]: crate::time::compute_duration_min
+"#]
 pub async fn insert_sleep(
     db: &Db,
     input: &SleepInput,
@@ -34,6 +87,15 @@ pub async fn insert_sleep(
     Ok(id)
 }
 
+#[doc = r#"Find a sleep session by wake date.
+
+Returns `Ok(None)` if no session exists for the provided date.
+
+See the example on [`insert_sleep`].
+
+# Errors
+- Returns [`sqlx::Error`] on database errors.
+"#]
 pub async fn find_sleep_by_date(
     db: &Db,
     date: NaiveDate,
@@ -47,6 +109,14 @@ pub async fn find_sleep_by_date(
     .await
 }
 
+#[doc = r#"Update a sleep session and its metrics in a single transaction.
+
+Requires a recomputed `duration_min`; see [`time::compute_duration_min`].
+See the example on [`insert_sleep`].
+
+# Errors
+- Returns [`sqlx::Error`] on database errors.
+"#]
 pub async fn update_sleep(
     db: &Db,
     id: i64,
@@ -75,6 +145,15 @@ pub async fn update_sleep(
     Ok(())
 }
 
+#[doc = r#"Delete a sleep session by id.
+
+Returns the number of rows affected (0 if no such id exists).
+
+See the example on [`insert_sleep`].
+
+# Errors
+- Returns [`sqlx::Error`] on database errors.
+"#]
 pub async fn delete_sleep(db: &Db, id: i64) -> Result<u64, sqlx::Error> {
     let res = sqlx::query::<Sqlite>("DELETE FROM sleep_sessions WHERE id = ?")
         .bind(id)
@@ -83,6 +162,34 @@ pub async fn delete_sleep(db: &Db, id: i64) -> Result<u64, sqlx::Error> {
     Ok(res.rows_affected())
 }
 
+#[doc = r#"Insert an exercise event.
+
+# Example (minimal)
+
+```rust,no_run
+# use sleep_api::domain::DomainError;
+# use std::error::Error;
+# use sleep_api::{db, repository, models::{ExerciseInput, Intensity}};
+# use chrono::NaiveDate;
+# async fn demo() -> Result<(), Box<dyn Error>> {
+std::env::set_var("DATABASE_URL", "sqlite::memory:");
+let db = db::connect().await?;
+sqlx::migrate::Migrator::new(std::path::Path::new("../migrations")).await?.run(&db).await?;
+
+let input = ExerciseInput {
+    date: NaiveDate::from_ymd_opt(2025, 6, 1).ok_or_else(|| DomainError::InvalidInput("invalid date".into()))?,
+    intensity: Intensity::Light,
+    start_time: None,
+    duration_min: Some(30),
+};
+input.validate()?;
+let id = repository::insert_exercise(&db, &input).await?;
+# Ok(()) }
+```
+
+# Errors
+- Returns [`sqlx::Error`] on database errors.
+"#]
 pub async fn insert_exercise(db: &Db, input: &ExerciseInput) -> Result<i64, sqlx::Error> {
     let mut tx: Transaction<'_, Sqlite> = db.begin().await?;
     let res = sqlx::query::<Sqlite>(
@@ -98,6 +205,34 @@ pub async fn insert_exercise(db: &Db, input: &ExerciseInput) -> Result<i64, sqlx
     Ok(res.last_insert_rowid())
 }
 
+#[doc = r#"Insert a note for a particular date.
+
+A `None` body is stored as NULL.
+
+# Example
+
+```rust,no_run
+# use sleep_api::domain::DomainError;
+# use std::error::Error;
+# use sleep_api::{db, repository, models::NoteInput};
+# use chrono::NaiveDate;
+# async fn demo() -> Result<(), Box<dyn Error>> {
+std::env::set_var("DATABASE_URL", "sqlite::memory:");
+let db = db::connect().await?;
+sqlx::migrate::Migrator::new(std::path::Path::new("../migrations")).await?.run(&db).await?;
+
+let input = NoteInput {
+    date: NaiveDate::from_ymd_opt(2025, 6, 1).ok_or_else(|| DomainError::InvalidInput("invalid date".into()))?,
+    body: Some("Slept well".to_string()),
+};
+input.validate()?;
+let id = repository::insert_note(&db, &input).await?;
+# Ok(()) }
+```
+
+# Errors
+- Returns [`sqlx::Error`] on database errors.
+"#]
 pub async fn insert_note(db: &Db, input: &NoteInput) -> Result<i64, sqlx::Error> {
     let res = sqlx::query::<Sqlite>("INSERT INTO notes(date, body) VALUES (?, ?)")
         .bind(input.date)

--- a/sleep-api/src/repository.rs
+++ b/sleep-api/src/repository.rs
@@ -35,7 +35,7 @@ Pass a precomputed `duration_min` (see [`time::compute_duration_min`]).
 # use sleep_api::{db, repository, models::{SleepInput, Quality}};
 # use chrono::{NaiveDate, NaiveTime};
 # async fn demo() -> Result<(), Box<dyn Error>> {
-std::env::set_var("DATABASE_URL", "sqlite::memory:");
+//// Ensure DATABASE_URL is set in the environment (e.g., sqlite::memory:).
 let db = db::connect().await?;
 sqlx::migrate::Migrator::new(std::path::Path::new("../migrations")).await?.run(&db).await?;
 
@@ -172,7 +172,7 @@ pub async fn delete_sleep(db: &Db, id: i64) -> Result<u64, sqlx::Error> {
 # use sleep_api::{db, repository, models::{ExerciseInput, Intensity}};
 # use chrono::NaiveDate;
 # async fn demo() -> Result<(), Box<dyn Error>> {
-std::env::set_var("DATABASE_URL", "sqlite::memory:");
+//// Ensure DATABASE_URL is set in the environment (e.g., sqlite::memory:).
 let db = db::connect().await?;
 sqlx::migrate::Migrator::new(std::path::Path::new("../migrations")).await?.run(&db).await?;
 
@@ -217,7 +217,7 @@ A `None` body is stored as NULL.
 # use sleep_api::{db, repository, models::NoteInput};
 # use chrono::NaiveDate;
 # async fn demo() -> Result<(), Box<dyn Error>> {
-std::env::set_var("DATABASE_URL", "sqlite::memory:");
+//// Ensure DATABASE_URL is set in the environment (e.g., sqlite::memory:).
 let db = db::connect().await?;
 sqlx::migrate::Migrator::new(std::path::Path::new("../migrations")).await?.run(&db).await?;
 

--- a/sleep-api/src/time.rs
+++ b/sleep-api/src/time.rs
@@ -68,9 +68,9 @@ DST handling:
 # fn main() -> Result<(), Box<dyn Error>> {
 // Cross-midnight: bed 23:00, wake 07:00 next day
 let mins = sleep_api::time::compute_duration_min(
-    NaiveDate::from_ymd_opt(2025, 6, 1).unwrap(),
-    NaiveTime::from_hms_opt(23, 0, 0).unwrap(),
-    NaiveTime::from_hms_opt(7, 0, 0).unwrap(),
+    NaiveDate::from_ymd_opt(2025, 6, 1).ok_or("invalid date")?,
+    NaiveTime::from_hms_opt(23, 0, 0).ok_or("invalid time")?,
+    NaiveTime::from_hms_opt(7, 0, 0).ok_or("invalid time")?,
     Tokyo,
 )?;
 assert_eq!(mins, 8 * 60);

--- a/sleep-api/src/time.rs
+++ b/sleep-api/src/time.rs
@@ -62,15 +62,15 @@ DST handling:
 # Example
 
 ```rust
-# use std::error::Error;
+# use sleep_api::domain::DomainError;
 # use chrono::{NaiveDate, NaiveTime};
 # use chrono_tz::Asia::Tokyo;
-# fn main() -> Result<(), Box<dyn Error>> {
+# fn main() -> Result<(), DomainError> {
 // Cross-midnight: bed 23:00, wake 07:00 next day
 let mins = sleep_api::time::compute_duration_min(
-    NaiveDate::from_ymd_opt(2025, 6, 1).ok_or("invalid date")?,
-    NaiveTime::from_hms_opt(23, 0, 0).ok_or("invalid time")?,
-    NaiveTime::from_hms_opt(7, 0, 0).ok_or("invalid time")?,
+    NaiveDate::from_ymd_opt(2025, 6, 1).ok_or_else(|| DomainError::InvalidInput("invalid date".into()))?,
+    NaiveTime::from_hms_opt(23, 0, 0).ok_or_else(|| DomainError::InvalidInput("invalid time".into()))?,
+    NaiveTime::from_hms_opt(7, 0, 0).ok_or_else(|| DomainError::InvalidInput("invalid time".into()))?,
     Tokyo,
 )?;
 assert_eq!(mins, 8 * 60);

--- a/sleep-api/src/views.rs
+++ b/sleep-api/src/views.rs
@@ -1,5 +1,29 @@
+#![doc = r#"Views and templates
+
+Server-side HTML rendering using Askama templates. Currently provides the trends page
+consumed by the `/trends` route in [`app`].
+
+Template: `templates/trends.html`
+
+[`app`]: crate::app
+"#]
+
 use askama::Template;
 
 #[derive(Template)]
 #[template(path = "trends.html")]
+#[doc = r#"Trends page template.
+
+Renders the trends page used by the `/trends` route.
+
+# Example
+
+```rust,no_run
+# use askama::Template;
+# fn main() -> Result<(), askama::Error> {
+let html = sleep_api::views::TrendsTemplate.render()?;
+assert!(!html.is_empty());
+# Ok(()) }
+```
+"#]
 pub struct TrendsTemplate;

--- a/sleep-api/src/views.rs
+++ b/sleep-api/src/views.rs
@@ -21,7 +21,7 @@ Renders the trends page used by the `/trends` route.
 ```rust,no_run
 # use askama::Template;
 # fn main() -> Result<(), askama::Error> {
-let html = crate::views::TrendsTemplate.render()?;
+let html = sleep_api::views::TrendsTemplate.render()?;
 assert!(!html.is_empty());
 # Ok(()) }
 ```

--- a/sleep-api/src/views.rs
+++ b/sleep-api/src/views.rs
@@ -21,7 +21,7 @@ Renders the trends page used by the `/trends` route.
 ```rust,no_run
 # use askama::Template;
 # fn main() -> Result<(), askama::Error> {
-let html = sleep_api::views::TrendsTemplate.render()?;
+let html = crate::views::TrendsTemplate.render()?;
 assert!(!html.is_empty());
 # Ok(()) }
 ```


### PR DESCRIPTION
This PR adds comprehensive documentation across the public API, aligning with C-EXAMPLE, C-QUESTION-MARK, C-FAILURE, C-LINK, C-METADATA, C-RELNOTES, and C-HIDDEN.

Summary:
- Crate-level docs with overview, example, and links to OpenAPI, API examples, and CHANGELOG.
- Module/item docs for app, config, db, domain, models, repository, time, trends, and views.
- Canonical examples (using `?`) and intra-doc links; doc tests marked `no_run` when touching DB/server.
- Errors sections for fallible functions; DST semantics documented for `time::compute_duration_min`.
- Hidden non-actionable impl in docs: `#[doc(hidden)] impl From<DomainError> for ApiError`.
- Cargo metadata (authors, description, license, repository, keywords, categories).
- Added CHANGELOG.md and linked from crate docs.

Notes:
- No behavioral changes except improved error handling in `trends_page` (logs and avoids unwrap).
- Consider enabling CI steps for `cargo doc` and `cargo test --doc` with strict rustdoc link lints.