### PR TITLE
PR-A: Backend Auth, CSRF, and Security Headers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,24 @@
+# SleepTracker example environment file
+# Copy to ".env" and adjust values for your environment.
+
+# SQLite connection string (file path or sqlite::memory: for ephemeral dev/testing)
+# Example for file-based DB (create directory as needed):
+# DATABASE_URL=sqlite://./data/sleep.db
+DATABASE_URL=sqlite::memory:
+
+# Admin credentials (single-user system)
+# Generate a password hash with:
+#   cargo run -p sleep-api --bin pw-hash
+# Then paste the full $argon2id$... string into ADMIN_PASSWORD_HASH.
+ADMIN_EMAIL=admin@example.com
+ADMIN_PASSWORD_HASH=$argon2id$v=19$REPLACE_WITH_HASH
+
+# Session and CSRF secrets (base64-encoded random bytes, 32+ bytes recommended)
+# You can generate with:
+#   Linux/macOS: head -c 32 /dev/urandom | base64
+#   PowerShell:  [Convert]::ToBase64String((1..32 | ForEach-Object {[byte](Get-Random -Max 256)}))
+SESSION_SECRET=REPLACE_WITH_BASE64_SECRET
+CSRF_SECRET=REPLACE_WITH_BASE64_SECRET
+
+# Optional: enable HSTS header (only when served over HTTPS/behind TLS)
+# ENABLE_HSTS=1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,6 +414,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "cookie_store"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eac901828f88a5241ee0600950ab981148a18f2f756900ffba1b125ca6a3ef9"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -529,6 +547,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -1203,6 +1230,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
+name = "litrs"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
+
+[[package]]
 name = "lock_api"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1585,6 +1618,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
+name = "publicsuffix"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
+dependencies = [
+ "idna",
+ "psl-types",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1646,6 +1695,8 @@ checksum = "eabf4c97d9130e2bf606614eb937e86edac8292eaa6f422f995d7e8de1eb1813"
 dependencies = [
  "base64",
  "bytes",
+ "cookie",
+ "cookie_store",
  "encoding_rs",
  "futures-core",
  "h2",

--- a/sleep-api/Cargo.toml
+++ b/sleep-api/Cargo.toml
@@ -25,7 +25,7 @@ thiserror = "2.0.12"
 hyper = "1"
 askama = "0.14"
 askama_web = { version = "0.14", features = ["axum-0.8"] }
-axum-extra = { version = "0.10", features = ["cookie", "cookie-signed"] }
+axum-extra = { version = "0.10", features = ["cookie", "cookie-signed", "cookie-private"] }
 tower-http = { version = "0.6", features = ["set-header", "fs"] }
 argon2 = "0.5"
 cookie = { version = "0.18", features = ["secure"] }
@@ -33,4 +33,4 @@ base64 = "0.22"
 rand = "0.8"
 
 [dev-dependencies]
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", features = ["json", "cookies"] }

--- a/sleep-api/src/app.rs
+++ b/sleep-api/src/app.rs
@@ -64,6 +64,29 @@ let app = sleep_api::app::router(db);
 [`Router`]: axum::Router
 "#]
 #[derive(Clone)]
+#[doc = r#"Application state for the Axum router.
+
+Holds shared components that extractors rely on:
+- [`Db`] — SQLx pool
+- [`Key`] — cookie crypto key for [`PrivateCookieJar`]
+
+Implements `FromRef` for `Db` and `Key` so handlers can extract them via `State<Db>` and extractors like `PrivateCookieJar`.
+
+# Example
+
+```rust,no_run
+# use axum::Router;
+# use axum_extra::extract::cookie::Key;
+# async fn demo(db: sleep_api::db::Db) {
+let state = sleep_api::app::AppState { db, key: sleep_api::config::session_key() };
+let app = Router::new().with_state(state);
+# }
+```
+
+[`Db`]: crate::db::Db
+[`Key`]: axum_extra::extract::cookie::Key
+[`PrivateCookieJar`]: axum_extra::extract::cookie::PrivateCookieJar
+"#]
 pub struct AppState {
     pub db: Db,
     pub key: Key,

--- a/sleep-api/src/app.rs
+++ b/sleep-api/src/app.rs
@@ -79,7 +79,7 @@ Implements `FromRef` for `Db` and `Key` so handlers can extract them via `State<
 # use axum_extra::extract::cookie::Key;
 # async fn demo(db: sleep_api::db::Db) {
 let state = sleep_api::app::AppState { db, key: sleep_api::config::session_key() };
-let app = Router::new().with_state(state);
+let app: Router<sleep_api::app::AppState> = Router::new().with_state(state);
 # }
 ```
 

--- a/sleep-api/src/app.rs
+++ b/sleep-api/src/app.rs
@@ -20,13 +20,17 @@ use crate::{
 };
 use askama::Template;
 use axum::http::StatusCode;
-use axum::response::Html;
+use axum::response::{Html, Redirect, IntoResponse};
 use axum::{
     Json, Router,
     extract::{Path, State},
     routing::{get, post, put},
 };
 use serde_json::json;
+use axum_extra::extract::cookie::{PrivateCookieJar, Key, Cookie, SameSite};
+use crate::auth::{self, LoginPayload};
+use crate::middleware::auth_layer::{RequireSessionJson, RequireSessionRedirect};
+use crate::security::csrf::{issue_csrf_cookie, CSRF_COOKIE, CsrfGuard};
 
 #[doc = r#"Build the application [`Router`].
 
@@ -59,9 +63,30 @@ let app = sleep_api::app::router(db);
 
 [`Router`]: axum::Router
 "#]
+#[derive(Clone)]
+pub struct AppState {
+    pub db: Db,
+    pub key: Key,
+}
+
+impl axum::extract::FromRef<AppState> for Db {
+    fn from_ref(s: &AppState) -> Db { s.db.clone() }
+}
+
+impl axum::extract::FromRef<AppState> for Key {
+    fn from_ref(s: &AppState) -> Key { s.key.clone() }
+}
+
 pub fn router(db: Db) -> Router {
-    Router::new()
+    let key: Key = crate::config::session_key();
+    let enable_hsts = crate::config::hsts_enabled();
+
+    let state = AppState { db, key: key.clone() };
+    let router = Router::new()
+        .route("/", get(root))
         .route("/health", get(|| async { Json(json!({"status":"ok"})) }))
+        .route("/login", get(get_login).post(post_login))
+        .route("/logout", post(post_logout))
         .route("/sleep", post(create_sleep))
         .route("/sleep/date/{date}", get(get_sleep))
         .route("/sleep/{id}", put(update_sleep).delete(delete_sleep))
@@ -70,11 +95,60 @@ pub fn router(db: Db) -> Router {
         .route("/api/trends/sleep-bars", get(trends::sleep_bars))
         .route("/api/trends/summary", get(trends::summary))
         .route("/trends", get(trends_page))
-        .with_state(db)
+        .with_state(state);
+
+    crate::security::headers::apply(router, enable_hsts)
+}
+
+async fn root(RequireSessionRedirect { _user_id: _ }: RequireSessionRedirect) -> Redirect {
+    Redirect::to("/trends")
+}
+
+async fn get_login() -> Html<String> {
+    let html = r#"<!doctype html>
+<html>
+<head><meta charset="utf-8"><title>Login</title></head>
+<body>
+  <h1>Login</h1>
+  <form method="post" action="/login">
+    <label>Email <input type="email" name="email" /></label><br/>
+    <label>Password <input type="password" name="password" /></label><br/>
+    <button type="submit">Login</button>
+  </form>
+</body>
+</html>"#;
+    Html(html.to_string())
+}
+
+async fn post_login(
+    jar: PrivateCookieJar,
+    Json(creds): Json<LoginPayload>,
+) -> axum::response::Response {
+    if auth::verify_login(&creds.email, &creds.password) {
+        let jar = auth::create_session_cookie(jar, "admin");
+        let jar = jar.add(issue_csrf_cookie());
+        (jar, Json(json!({"ok": true}))).into_response()
+    } else {
+        (StatusCode::UNAUTHORIZED, Json(json!({"error":"unauthorized"}))).into_response()
+    }
+}
+
+async fn post_logout(mut jar: PrivateCookieJar) -> axum::response::Response {
+    jar = auth::clear_session_cookie(jar);
+    let csrf = Cookie::build((CSRF_COOKIE, String::new()))
+        .path("/")
+        .secure(true)
+        .http_only(false)
+        .same_site(SameSite::Lax)
+        .build();
+    jar = jar.remove(csrf);
+    (jar, StatusCode::NO_CONTENT).into_response()
 }
 
 async fn create_sleep(
     State(db): State<Db>,
+    RequireSessionJson { _user_id: _ }: RequireSessionJson,
+    _csrf: CsrfGuard,
     Json(input): Json<SleepInput>,
 ) -> Result<impl axum::response::IntoResponse, ApiError> {
     let id = handlers::create_sleep(&db, input).await?;
@@ -94,6 +168,8 @@ async fn get_sleep(
 async fn update_sleep(
     State(db): State<Db>,
     Path(id): Path<i64>,
+    RequireSessionJson { _user_id: _ }: RequireSessionJson,
+    _csrf: CsrfGuard,
     Json(input): Json<SleepInput>,
 ) -> Result<impl axum::response::IntoResponse, ApiError> {
     handlers::update_sleep(&db, id, input).await?;
@@ -103,6 +179,8 @@ async fn update_sleep(
 async fn delete_sleep(
     State(db): State<Db>,
     Path(id): Path<i64>,
+    RequireSessionJson { _user_id: _ }: RequireSessionJson,
+    _csrf: CsrfGuard,
 ) -> Result<impl axum::response::IntoResponse, ApiError> {
     let affected = handlers::delete_sleep(&db, id).await?;
     if affected == 0 {
@@ -114,6 +192,8 @@ async fn delete_sleep(
 
 async fn create_exercise(
     State(db): State<Db>,
+    RequireSessionJson { _user_id: _ }: RequireSessionJson,
+    _csrf: CsrfGuard,
     Json(input): Json<ExerciseInput>,
 ) -> Result<impl axum::response::IntoResponse, ApiError> {
     let id = handlers::create_exercise(&db, input).await?;
@@ -122,13 +202,15 @@ async fn create_exercise(
 
 async fn create_note(
     State(db): State<Db>,
+    RequireSessionJson { _user_id: _ }: RequireSessionJson,
+    _csrf: CsrfGuard,
     Json(input): Json<NoteInput>,
 ) -> Result<impl axum::response::IntoResponse, ApiError> {
     let id = handlers::create_note(&db, input).await?;
     Ok((StatusCode::CREATED, Json(json!({"id": id}))))
 }
 
-async fn trends_page() -> Html<String> {
+async fn trends_page(RequireSessionRedirect { _user_id: _ }: RequireSessionRedirect) -> Html<String> {
     let tpl = super::views::TrendsTemplate;
     match tpl.render() {
         Ok(html) => Html(html),

--- a/sleep-api/src/auth.rs
+++ b/sleep-api/src/auth.rs
@@ -38,7 +38,10 @@ pub fn current_user_from_cookie(jar: &PrivateCookieJar) -> Option<UserId> {
 
 /// Verify provided email + password against configured ADMIN_EMAIL + ADMIN_PASSWORD_HASH.
 pub fn verify_login(email: &str, password: &str) -> bool {
-    use argon2::{password_hash::{PasswordHash, PasswordVerifier}, Argon2};
+    use argon2::{
+        Argon2,
+        password_hash::{PasswordHash, PasswordVerifier},
+    };
 
     let admin_email = crate::config::admin_email();
     if email != admin_email {

--- a/sleep-api/src/auth.rs
+++ b/sleep-api/src/auth.rs
@@ -1,0 +1,68 @@
+use axum_extra::extract::cookie::{Cookie, PrivateCookieJar, SameSite};
+use cookie as _;
+use serde::Deserialize;
+
+pub type UserId = String;
+
+pub const SESSION_COOKIE: &str = "__Host-session";
+
+/// Create a secure, HttpOnly session cookie storing the user id (encrypted via PrivateCookieJar).
+pub fn create_session_cookie(mut jar: PrivateCookieJar, user_id: &str) -> PrivateCookieJar {
+    let cookie = Cookie::build((SESSION_COOKIE, user_id.to_owned()))
+        .path("/")
+        .secure(true)
+        .http_only(true)
+        .same_site(SameSite::Lax)
+        .build();
+    jar = jar.add(cookie);
+    jar
+}
+
+/// Clear the session cookie.
+pub fn clear_session_cookie(mut jar: PrivateCookieJar) -> PrivateCookieJar {
+    // Removal needs to match name + path
+    let cookie = Cookie::build((SESSION_COOKIE, String::new()))
+        .path("/")
+        .secure(true)
+        .http_only(true)
+        .same_site(SameSite::Lax)
+        .build();
+    jar = jar.remove(cookie);
+    jar
+}
+
+/// Return the current user id from the session cookie if present/valid.
+pub fn current_user_from_cookie(jar: &PrivateCookieJar) -> Option<UserId> {
+    jar.get(SESSION_COOKIE).map(|c| c.value().to_string())
+}
+
+/// Verify provided email + password against configured ADMIN_EMAIL + ADMIN_PASSWORD_HASH.
+pub fn verify_login(email: &str, password: &str) -> bool {
+    use argon2::{password_hash::{PasswordHash, PasswordVerifier}, Argon2};
+
+    let admin_email = crate::config::admin_email();
+    if email != admin_email {
+        return false;
+    }
+    let hash = crate::config::admin_password_hash();
+    if hash.is_empty() {
+        // Lock out if not configured
+        return false;
+    }
+    let parsed = match PasswordHash::new(&hash) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!(error=?e, "invalid ADMIN_PASSWORD_HASH value");
+            return false;
+        }
+    };
+    Argon2::default()
+        .verify_password(password.as_bytes(), &parsed)
+        .is_ok()
+}
+
+#[derive(Debug, Deserialize)]
+pub struct LoginPayload {
+    pub email: String,
+    pub password: String,
+}

--- a/sleep-api/src/bin/pw-hash.rs
+++ b/sleep-api/src/bin/pw-hash.rs
@@ -1,0 +1,15 @@
+use argon2::{password_hash::{PasswordHasher, SaltString}, Argon2};
+use std::io::{self, Read};
+
+fn main() {
+    // Read password from stdin (echoed). To avoid echo, consider using the `rpassword` crate.
+    eprintln!("Enter password on stdin. Input will be echoed. Press Ctrl+D (Unix) or Ctrl+Z then Enter (Windows) to end:");
+    let mut buf = String::new();
+    io::stdin().read_to_string(&mut buf).expect("failed to read stdin");
+    let password = buf.trim_end_matches(&['\n', '\r'][..]).as_bytes();
+
+    let salt = SaltString::generate(rand::rngs::OsRng);
+    let argon2 = Argon2::default();
+    let hash = argon2.hash_password(password, &salt).expect("hashing failed");
+    println!("{}", hash.to_string());
+}

--- a/sleep-api/src/bin/pw-hash.rs
+++ b/sleep-api/src/bin/pw-hash.rs
@@ -1,3 +1,15 @@
+//! Password hash generator (Argon2id)
+//!
+//! Reads a password from stdin and prints an `$argon2id$...` hash suitable for
+//! the `ADMIN_PASSWORD_HASH` environment variable.
+//!
+//! Usage (examples):
+//! ```text
+//! cargo run -p sleep-api --bin pw-hash
+//! ```
+//!
+//! Note: Input is echoed. For non-echoing input, consider the `rpassword` crate.
+
 use argon2::{
     Argon2,
     password_hash::{PasswordHasher, SaltString},

--- a/sleep-api/src/bin/pw-hash.rs
+++ b/sleep-api/src/bin/pw-hash.rs
@@ -11,5 +11,5 @@ fn main() {
     let salt = SaltString::generate(rand::rngs::OsRng);
     let argon2 = Argon2::default();
     let hash = argon2.hash_password(password, &salt).expect("hashing failed");
-    println!("{}", hash.to_string());
+    println!("{hash}");
 }

--- a/sleep-api/src/bin/pw-hash.rs
+++ b/sleep-api/src/bin/pw-hash.rs
@@ -1,15 +1,24 @@
-use argon2::{password_hash::{PasswordHasher, SaltString}, Argon2};
+use argon2::{
+    Argon2,
+    password_hash::{PasswordHasher, SaltString},
+};
 use std::io::{self, Read};
 
 fn main() {
     // Read password from stdin (echoed). To avoid echo, consider using the `rpassword` crate.
-    eprintln!("Enter password on stdin. Input will be echoed. Press Ctrl+D (Unix) or Ctrl+Z then Enter (Windows) to end:");
+    eprintln!(
+        "Enter password on stdin. Input will be echoed. Press Ctrl+D (Unix) or Ctrl+Z then Enter (Windows) to end:"
+    );
     let mut buf = String::new();
-    io::stdin().read_to_string(&mut buf).expect("failed to read stdin");
+    io::stdin()
+        .read_to_string(&mut buf)
+        .expect("failed to read stdin");
     let password = buf.trim_end_matches(&['\n', '\r'][..]).as_bytes();
 
     let salt = SaltString::generate(rand::rngs::OsRng);
     let argon2 = Argon2::default();
-    let hash = argon2.hash_password(password, &salt).expect("hashing failed");
+    let hash = argon2
+        .hash_password(password, &salt)
+        .expect("hashing failed");
     println!("{hash}");
 }

--- a/sleep-api/src/config.rs
+++ b/sleep-api/src/config.rs
@@ -42,18 +42,41 @@ pub fn app_tz() -> Tz {
 }
 
 /// Return the admin email from ADMIN_EMAIL (defaults to admin@example.com).
+#[doc = r#"Return the admin email from the `ADMIN_EMAIL` environment variable.
+
+Defaults to `admin@example.com` if unset.
+
+# Example
+
+```rust,no_run
+# unsafe {
+std::env::set_var("ADMIN_EMAIL", "owner@example.com");
+assert_eq!(sleep_api::config::admin_email(), "owner@example.com");
+# }
+```"#]
 pub fn admin_email() -> String {
     std::env::var("ADMIN_EMAIL").unwrap_or_else(|_| "admin@example.com".to_string())
 }
 
 /// Return the admin password hash from ADMIN_PASSWORD_HASH (argon2id string).
 /// Returns empty string if unset, causing login to fail.
+#[doc = r#"Return the admin password hash from `ADMIN_PASSWORD_HASH`.
+
+Expected format is an Argon2id hash string (e.g., `$argon2id$...`). Returns empty string if unset,
+which causes login verification to fail."#]
 pub fn admin_password_hash() -> String {
     std::env::var("ADMIN_PASSWORD_HASH").unwrap_or_default()
 }
 
 /// Build a cookie Key from SESSION_SECRET if provided (base64), otherwise generate a random key.
 /// A stable key is recommended for production to allow restarting without invalidating sessions.
+#[doc = r#"Build a cookie [`Key`] from `SESSION_SECRET` (base64) or generate a random key.
+
+A stable `SESSION_SECRET` is recommended for production to avoid invalidating sessions on restart.
+If the environment variable is absent or invalid, a new random key is generated.
+
+[`Key`]: axum_extra::extract::cookie::Key
+"#]
 pub fn session_key() -> axum_extra::extract::cookie::Key {
     use base64::{Engine as _, engine::general_purpose};
     if let Ok(val) = std::env::var("SESSION_SECRET") {
@@ -70,6 +93,10 @@ pub fn session_key() -> axum_extra::extract::cookie::Key {
 }
 
 /// Whether to enable the HSTS header. Controlled by ENABLE_HSTS=1/true.
+#[doc = r#"Return whether to enable the HSTS header.
+
+Reads `ENABLE_HSTS` and treats `1` or `true` (case-insensitive) as enabled.
+Only enable when serving over HTTPS or behind TLS-terminating proxy."#]
 pub fn hsts_enabled() -> bool {
     match std::env::var("ENABLE_HSTS") {
         Ok(v) => v == "1" || v.eq_ignore_ascii_case("true"),

--- a/sleep-api/src/config.rs
+++ b/sleep-api/src/config.rs
@@ -55,7 +55,7 @@ pub fn admin_password_hash() -> String {
 /// Build a cookie Key from SESSION_SECRET if provided (base64), otherwise generate a random key.
 /// A stable key is recommended for production to allow restarting without invalidating sessions.
 pub fn session_key() -> axum_extra::extract::cookie::Key {
-    use base64::{engine::general_purpose, Engine as _};
+    use base64::{Engine as _, engine::general_purpose};
     if let Ok(val) = std::env::var("SESSION_SECRET") {
         match general_purpose::STANDARD.decode(val.as_bytes()) {
             Ok(bytes) => {

--- a/sleep-api/src/lib.rs
+++ b/sleep-api/src/lib.rs
@@ -56,3 +56,6 @@ pub mod repository;
 pub mod time;
 pub mod trends;
 pub mod views;
+pub mod auth;
+pub mod middleware;
+pub mod security;

--- a/sleep-api/src/lib.rs
+++ b/sleep-api/src/lib.rs
@@ -46,16 +46,16 @@ See also: [`time`], [`repository`], and [`models`].
 "#]
 
 pub mod app;
+pub mod auth;
 pub mod config;
 pub mod db;
 pub mod domain;
 mod error;
 mod handlers;
+pub mod middleware;
 pub mod models;
 pub mod repository;
+pub mod security;
 pub mod time;
 pub mod trends;
 pub mod views;
-pub mod auth;
-pub mod middleware;
-pub mod security;

--- a/sleep-api/src/main.rs
+++ b/sleep-api/src/main.rs
@@ -9,6 +9,9 @@ mod repository;
 mod time;
 mod trends;
 mod views;
+mod auth;
+mod middleware;
+mod security;
 
 use crate::db::connect;
 use tokio::net::TcpListener;

--- a/sleep-api/src/main.rs
+++ b/sleep-api/src/main.rs
@@ -1,17 +1,17 @@
 mod app;
+mod auth;
 mod config;
 mod db;
 mod domain;
 mod error;
 mod handlers;
+mod middleware;
 mod models;
 mod repository;
+mod security;
 mod time;
 mod trends;
 mod views;
-mod auth;
-mod middleware;
-mod security;
 
 use crate::db::connect;
 use tokio::net::TcpListener;

--- a/sleep-api/src/middleware/auth_layer.rs
+++ b/sleep-api/src/middleware/auth_layer.rs
@@ -1,3 +1,34 @@
+#![doc = r#"Authentication extractors
+
+Provides extractors to require a valid session:
+- [`RequireSessionJson`] → returns `401` JSON (`{"error":"unauthorized"}`) on failure
+- [`RequireSessionRedirect`] → redirects to `/login` on failure (for UI routes)
+
+These extractors read the encrypted `__Host-session` cookie via [`PrivateCookieJar`]. They require that the application state implements [`FromRef`] for [`Key`], which is provided by [`app::AppState`].
+
+# Example
+
+```rust,no_run
+# use axum::{Json, response::IntoResponse};
+# use sleep_api::middleware::auth_layer::{RequireSessionJson, RequireSessionRedirect};
+# async fn api_handler(
+#     RequireSessionJson { _user_id: _ }: RequireSessionJson,
+#     Json(_): Json<serde_json::Value>,
+# ) -> impl IntoResponse {
+#     axum::http::StatusCode::NO_CONTENT
+# }
+# async fn ui_handler(
+#     RequireSessionRedirect { _user_id: _ }: RequireSessionRedirect,
+# ) -> axum::response::Html<String> {
+#     axum::response::Html(String::new())
+# }
+```
+
+See also:
+- [`crate::auth`] for creating/clearing session cookies
+- [`crate::security::csrf`] for CSRF protection guard
+"#]
+
 use axum::extract::{FromRef, FromRequestParts};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Redirect, Response};

--- a/sleep-api/src/middleware/auth_layer.rs
+++ b/sleep-api/src/middleware/auth_layer.rs
@@ -1,18 +1,22 @@
-use axum::extract::{FromRequestParts, FromRef};
+use axum::extract::{FromRef, FromRequestParts};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Redirect, Response};
-use axum_extra::extract::cookie::{PrivateCookieJar, Key};
+use axum_extra::extract::cookie::{Key, PrivateCookieJar};
 use serde_json::json;
 
-use crate::auth::{current_user_from_cookie, UserId};
+use crate::auth::{UserId, current_user_from_cookie};
 
 /// Extractor that requires an authenticated session for JSON APIs.
 /// On failure, returns 401 with a JSON error payload.
-pub struct RequireSessionJson { pub _user_id: UserId }
+pub struct RequireSessionJson {
+    pub _user_id: UserId,
+}
 
 /// Extractor that requires an authenticated session for UI routes.
 /// On failure, redirects to /login.
-pub struct RequireSessionRedirect { pub _user_id: UserId }
+pub struct RequireSessionRedirect {
+    pub _user_id: UserId,
+}
 
 impl<S> FromRequestParts<S> for RequireSessionJson
 where
@@ -57,7 +61,11 @@ where
 }
 
 fn unauthorized() -> Response {
-    (StatusCode::UNAUTHORIZED, axum::Json(json!({"error":"unauthorized"}))).into_response()
+    (
+        StatusCode::UNAUTHORIZED,
+        axum::Json(json!({"error":"unauthorized"})),
+    )
+        .into_response()
 }
 
 fn redirect_login() -> Response {

--- a/sleep-api/src/middleware/auth_layer.rs
+++ b/sleep-api/src/middleware/auth_layer.rs
@@ -1,0 +1,63 @@
+use axum::extract::FromRequestParts;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Redirect, Response};
+use axum_extra::extract::cookie::PrivateCookieJar;
+use serde_json::json;
+
+use crate::auth::{current_user_from_cookie, UserId};
+
+/// Extractor that requires an authenticated session for JSON APIs.
+/// On failure, returns 401 with a JSON error payload.
+pub struct RequireSessionJson(pub UserId);
+
+/// Extractor that requires an authenticated session for UI routes.
+/// On failure, redirects to /login.
+pub struct RequireSessionRedirect(pub UserId);
+
+impl<S> FromRequestParts<S> for RequireSessionJson
+where
+    S: Send + Sync,
+{
+    type Rejection = Response;
+
+    async fn from_request_parts(
+        parts: &mut axum::http::request::Parts,
+        state: &S,
+    ) -> Result<Self, Self::Rejection> {
+        let jar = PrivateCookieJar::from_request_parts(parts, state)
+            .await
+            .map_err(|_| unauthorized())?;
+        match current_user_from_cookie(&jar) {
+            Some(uid) => Ok(Self(uid)),
+            None => Err(unauthorized()),
+        }
+    }
+}
+
+impl<S> FromRequestParts<S> for RequireSessionRedirect
+where
+    S: Send + Sync,
+{
+    type Rejection = Response;
+
+    async fn from_request_parts(
+        parts: &mut axum::http::request::Parts,
+        state: &S,
+    ) -> Result<Self, Self::Rejection> {
+        let jar = PrivateCookieJar::from_request_parts(parts, state)
+            .await
+            .map_err(|_| redirect_login())?;
+        match current_user_from_cookie(&jar) {
+            Some(uid) => Ok(Self(uid)),
+            None => Err(redirect_login()),
+        }
+    }
+}
+
+fn unauthorized() -> Response {
+    (StatusCode::UNAUTHORIZED, axum::Json(json!({"error":"unauthorized"}))).into_response()
+}
+
+fn redirect_login() -> Response {
+    Redirect::to("/login").into_response()
+}

--- a/sleep-api/src/middleware/mod.rs
+++ b/sleep-api/src/middleware/mod.rs
@@ -1,0 +1,1 @@
+pub mod auth_layer;

--- a/sleep-api/src/middleware/mod.rs
+++ b/sleep-api/src/middleware/mod.rs
@@ -1,1 +1,13 @@
+#![doc = r#"Middleware utilities
+
+Authentication-related extractors for protecting routes.
+
+Modules:
+- [`auth_layer`] — extractors that require a valid session (`__Host-session`)
+
+See also:
+- [`crate::security::csrf`] for CSRF enforcement on mutating requests
+- [`crate::auth`] for session cookie helpers
+"#]
+
 pub mod auth_layer;

--- a/sleep-api/src/security/csrf.rs
+++ b/sleep-api/src/security/csrf.rs
@@ -1,0 +1,86 @@
+use axum::extract::FromRequestParts;
+use axum::http::{header::HeaderName, Method, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum_extra::extract::cookie::{Cookie, CookieJar, SameSite};
+use serde_json::json;
+
+pub const CSRF_COOKIE: &str = "__Host-csrf";
+
+/// Issue a CSRF cookie with a random 32-byte base64 value.
+/// - Secure
+/// - SameSite=Lax
+/// - Path=/
+/// - Not HttpOnly (so a future UI may read and echo it via X-CSRF-Token)
+pub fn issue_csrf_cookie() -> Cookie<'static> {
+    let mut bytes = [0u8; 32];
+    rand::rngs::OsRng.fill_bytes(&mut bytes);
+    let token = base64::engine::general_purpose::STANDARD.encode(bytes);
+
+    Cookie::build((CSRF_COOKIE, token))
+        .path("/")
+        .secure(true)
+        .http_only(false)
+        .same_site(SameSite::Lax)
+        .build()
+}
+
+/// Guard extractor that enforces double-submit CSRF for mutating methods (POST/PUT/DELETE).
+/// - Requires a cookie "__Host-csrf"
+/// - Requires header "X-CSRF-Token" matching the cookie value
+/// - If "Sec-Fetch-Site" header is present, it must be "same-origin" or "same-site"
+pub struct CsrfGuard;
+
+impl<S> FromRequestParts<S> for CsrfGuard
+where
+    S: Send + Sync,
+{
+    type Rejection = Response;
+
+    async fn from_request_parts(parts: &mut axum::http::request::Parts, state: &S) -> Result<Self, Self::Rejection> {
+        // Only enforce on mutating methods
+        let method = parts.method.clone();
+        let is_mutating = matches!(method, Method::POST | Method::PUT | Method::DELETE);
+        if !is_mutating {
+            return Ok(Self);
+        }
+
+        // Basic same-site heuristic via Sec-Fetch-Site if provided
+        if let Some(h) = parts.headers.get("sec-fetch-site") {
+            if let Ok(v) = h.to_str() {
+                let v = v.to_ascii_lowercase();
+                if v != "same-origin" && v != "same-site" {
+                    return Err(forbidden("csrf: cross-site request rejected"));
+                }
+            }
+        }
+
+        // Read CSRF cookie
+        let jar = CookieJar::from_request_parts(parts, state)
+            .await
+            .unwrap_or_else(|_| CookieJar::new());
+        let cookie_val = match jar.get(CSRF_COOKIE) {
+            Some(c) => c.value().to_string(),
+            None => return Err(forbidden("csrf: missing cookie")),
+        };
+
+        // Compare against header X-CSRF-Token
+        static X_CSRF_TOKEN: HeaderName = HeaderName::from_static("x-csrf-token");
+        let hdr = parts.headers.get(&X_CSRF_TOKEN)
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string());
+
+        let Some(token) = hdr else {
+            return Err(forbidden("csrf: missing header token"));
+        };
+
+        if token != cookie_val {
+            return Err(forbidden("csrf: token mismatch"));
+        }
+
+        Ok(Self)
+    }
+}
+
+fn forbidden(detail: &str) -> Response {
+    (StatusCode::FORBIDDEN, axum::Json(json!({"error":"forbidden","detail": detail}))).into_response()
+}

--- a/sleep-api/src/security/headers.rs
+++ b/sleep-api/src/security/headers.rs
@@ -1,3 +1,20 @@
+#![doc = r#"Security headers layer
+
+Adds common security headers to all responses:
+- `X-Content-Type-Options: nosniff`
+- `X-Frame-Options: DENY`
+- `Referrer-Policy: strict-origin-when-cross-origin`
+- Content Security Policy (baseline): `default-src 'self'; script-src 'self' 'unsafe-inline'`
+- Strict-Transport-Security when `ENABLE_HSTS=1/true`
+
+# Example
+
+```rust,no_run
+# let router = axum::Router::new();
+let router = sleep_api::security::headers::apply(router, sleep_api::config::hsts_enabled());
+```
+"#]
+
 use axum::Router;
 use axum::http::{HeaderName, HeaderValue};
 use tower_http::set_header::SetResponseHeaderLayer;

--- a/sleep-api/src/security/headers.rs
+++ b/sleep-api/src/security/headers.rs
@@ -8,7 +8,10 @@ use tower_http::set_header::SetResponseHeaderLayer;
 /// - Referrer-Policy: strict-origin-when-cross-origin
 /// - Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'
 /// - Strict-Transport-Security (optional when enable_hsts=true)
-pub fn apply(mut router: Router, enable_hsts: bool) -> Router {
+pub fn apply<S>(mut router: Router<S>, enable_hsts: bool) -> Router<S>
+where
+    S: Clone + Send + Sync + 'static,
+{
     router = router
         .layer(SetResponseHeaderLayer::if_not_present(
             HeaderName::from_static("x-content-type-options"),

--- a/sleep-api/src/security/headers.rs
+++ b/sleep-api/src/security/headers.rs
@@ -10,7 +10,7 @@ Adds common security headers to all responses:
 # Example
 
 ```rust,no_run
-# let router = axum::Router::new();
+# let router: axum::Router<()> = axum::Router::new();
 let router = sleep_api::security::headers::apply(router, sleep_api::config::hsts_enabled());
 ```
 "#]

--- a/sleep-api/src/security/headers.rs
+++ b/sleep-api/src/security/headers.rs
@@ -1,0 +1,38 @@
+use axum::Router;
+use axum::http::{HeaderName, HeaderValue};
+use tower_http::set_header::SetResponseHeaderLayer;
+
+/// Apply common security headers to all responses.
+/// - X-Content-Type-Options: nosniff
+/// - X-Frame-Options: DENY
+/// - Referrer-Policy: strict-origin-when-cross-origin
+/// - Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'
+/// - Strict-Transport-Security (optional when enable_hsts=true)
+pub fn apply(mut router: Router, enable_hsts: bool) -> Router {
+    router = router
+        .layer(SetResponseHeaderLayer::if_not_present(
+            HeaderName::from_static("x-content-type-options"),
+            HeaderValue::from_static("nosniff"),
+        ))
+        .layer(SetResponseHeaderLayer::if_not_present(
+            HeaderName::from_static("x-frame-options"),
+            HeaderValue::from_static("DENY"),
+        ))
+        .layer(SetResponseHeaderLayer::if_not_present(
+            HeaderName::from_static("referrer-policy"),
+            HeaderValue::from_static("strict-origin-when-cross-origin"),
+        ))
+        .layer(SetResponseHeaderLayer::if_not_present(
+            HeaderName::from_static("content-security-policy"),
+            HeaderValue::from_static("default-src 'self'; script-src 'self' 'unsafe-inline'"),
+        ));
+
+    if enable_hsts {
+        router = router.layer(SetResponseHeaderLayer::if_not_present(
+            HeaderName::from_static("strict-transport-security"),
+            HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+        ));
+    }
+
+    router
+}

--- a/sleep-api/src/security/mod.rs
+++ b/sleep-api/src/security/mod.rs
@@ -1,0 +1,2 @@
+pub mod csrf;
+pub mod headers;

--- a/sleep-api/src/security/mod.rs
+++ b/sleep-api/src/security/mod.rs
@@ -1,2 +1,14 @@
+#![doc = r#"Security utilities
+
+Provides CSRF protection (double-submit cookie) and common HTTP security headers.
+
+Modules:
+- [`csrf`] — double-submit cookie issuance and request guard
+- [`headers`] — response header layer (HSTS, CSP, X-Frame-Options, Referrer-Policy, etc.)
+
+See also:
+- [`crate::middleware::auth_layer`] for session-based access control
+"#]
+
 pub mod csrf;
 pub mod headers;

--- a/sleep-api/src/trends.rs
+++ b/sleep-api/src/trends.rs
@@ -22,7 +22,7 @@ use std::collections::BTreeMap;
 /// Helper to parse a date string and return ApiError with field name
 fn parse_date_field(s: &str, field: &str) -> Result<NaiveDate, ApiError> {
     NaiveDate::parse_from_str(s, "%Y-%m-%d")
-        .map_err(|_| ApiError::InvalidInput(format!("invalid {} date", field)))
+        .map_err(|_| ApiError::InvalidInput(format!("invalid {field} date")))
 }
 
 /// Helper to parse and validate a from/to date range (YYYY-MM-DD)

--- a/sleep-api/tests/api_sleep.rs
+++ b/sleep-api/tests/api_sleep.rs
@@ -2,10 +2,63 @@ use reqwest::Client;
 use sleep_api::models::{Quality, SleepInput, SleepSession};
 use sleep_api::{app, db};
 use sqlx::Row;
+use argon2::{password_hash::{PasswordHasher, SaltString}, Argon2};
+
+fn set_admin_env(email: &str, password: &str) {
+    let salt = SaltString::generate(rand::rngs::OsRng);
+    let argon2 = Argon2::default();
+    let hash = argon2.hash_password(password.as_bytes(), &salt).unwrap().to_string();
+    unsafe {
+        std::env::set_var("ADMIN_EMAIL", email);
+        std::env::set_var("ADMIN_PASSWORD_HASH", hash);
+    }
+}
+
+async fn wait_ready(client: &Client, addr: &str) {
+    let health_url = format!("http://{}/health", addr);
+    for _ in 0..20 {
+        if client.get(&health_url).send().await.is_ok() {
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    panic!("Server did not become ready in time");
+}
+
+fn parse_cookie<'a>(headers: impl Iterator<Item = &'a reqwest::header::HeaderValue>, name_with_eq: &str) -> Option<String> {
+    for hv in headers {
+        if let Ok(s) = hv.to_str() {
+            if s.starts_with(name_with_eq) {
+                if let Some(eq_idx) = s.find('=') {
+                    let rest = &s[eq_idx + 1..];
+                    let end = rest.find(';').unwrap_or(rest.len());
+                    return Some(rest[..end].to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
+async fn login_and_get_auth(client: &Client, addr: &str, email: &str, password: &str) -> (String, String) {
+    let res = client
+        .post(&format!("http://{}/login", addr))
+        .json(&serde_json::json!({ "email": email, "password": password }))
+        .send()
+        .await
+        .expect("login request failed");
+    assert_eq!(res.status(), 200, "login failed: {}", res.status());
+    let headers = res.headers().get_all(reqwest::header::SET_COOKIE);
+    let csrf = parse_cookie(headers.iter(), "__Host-csrf=").expect("missing __Host-csrf cookie");
+    let session = parse_cookie(headers.iter(), "__Host-session=").expect("missing __Host-session cookie");
+    (csrf, session)
+}
 
 #[tokio::test]
 async fn test_sleep_flow() {
     unsafe { std::env::set_var("DATABASE_URL", "sqlite::memory:") };
+    set_admin_env("admin@example.com", "password123");
+
     let pool = db::connect().await.unwrap();
     sqlx::migrate::Migrator::new(std::path::Path::new("../migrations"))
         .await
@@ -14,23 +67,18 @@ async fn test_sleep_flow() {
         .await
         .unwrap();
     let app = app::router(pool.clone());
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let listener = tokio::net::TcpListener::bind("127.0.0.2:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     let server = tokio::spawn(async move {
         axum::serve(listener, app).await.unwrap();
     });
 
-    let client = Client::new();
-    let health_url = format!("http://{}/health", addr);
-    let mut ready = false;
-    for _ in 0..10 {
-        if client.get(&health_url).send().await.is_ok() {
-            ready = true;
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-    }
-    assert!(ready, "Server did not become ready in time");
+    let client = Client::builder().cookie_store(true).build().unwrap();
+    wait_ready(&client, &addr.to_string()).await;
+
+    // Login and get CSRF token
+    let (csrf, session_cookie) = login_and_get_auth(&client, &addr.to_string(), "admin@example.com", "password123").await;
+
     let input = SleepInput {
         date: chrono::NaiveDate::from_ymd_opt(2025, 6, 17).unwrap(),
         bed_time: chrono::NaiveTime::from_hms_opt(22, 5, 0).unwrap(),
@@ -41,6 +89,8 @@ async fn test_sleep_flow() {
     };
     let res = client
         .post(&format!("http://{}/sleep", addr))
+        .header("Cookie", format!("__Host-session={}; __Host-csrf={}", session_cookie, csrf))
+        .header("X-CSRF-Token", &csrf)
         .json(&input)
         .send()
         .await
@@ -67,6 +117,8 @@ async fn test_sleep_flow() {
     };
     let res = client
         .put(&format!("http://{}/sleep/{}", addr, id))
+        .header("Cookie", format!("__Host-session={}; __Host-csrf={}", session_cookie, csrf))
+        .header("X-CSRF-Token", &csrf)
         .json(&updated)
         .send()
         .await
@@ -85,6 +137,8 @@ async fn test_sleep_flow() {
 
     let res = client
         .delete(&format!("http://{}/sleep/{}", addr, id))
+        .header("Cookie", format!("__Host-session={}; __Host-csrf={}", session_cookie, csrf))
+        .header("X-CSRF-Token", &csrf)
         .send()
         .await
         .unwrap();
@@ -103,6 +157,8 @@ async fn test_sleep_flow() {
 #[tokio::test]
 async fn test_exercise_and_note() {
     unsafe { std::env::set_var("DATABASE_URL", "sqlite::memory:") };
+    set_admin_env("admin@example.com", "password123");
+
     let pool = db::connect().await.unwrap();
     sqlx::migrate::Migrator::new(std::path::Path::new("../migrations"))
         .await
@@ -111,23 +167,17 @@ async fn test_exercise_and_note() {
         .await
         .unwrap();
     let app = app::router(pool.clone());
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let listener = tokio::net::TcpListener::bind("127.0.0.2:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     let server = tokio::spawn(async move {
         axum::serve(listener, app).await.unwrap();
     });
 
-    let client = Client::new();
-    let health_url = format!("http://{}/health", addr);
-    let mut ready = false;
-    for _ in 0..10 {
-        if client.get(&health_url).send().await.is_ok() {
-            ready = true;
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-    }
-    assert!(ready, "Server did not become ready in time");
+    let client = Client::builder().cookie_store(true).build().unwrap();
+    wait_ready(&client, &addr.to_string()).await;
+
+    // Login and get CSRF token
+    let (csrf, session_cookie) = login_and_get_auth(&client, &addr.to_string(), "admin@example.com", "password123").await;
 
     let exercise = sleep_api::models::ExerciseInput {
         date: chrono::NaiveDate::from_ymd_opt(2025, 6, 17).unwrap(),
@@ -137,6 +187,8 @@ async fn test_exercise_and_note() {
     };
     let res = client
         .post(&format!("http://{}/exercise", addr))
+        .header("Cookie", format!("__Host-session={}; __Host-csrf={}", session_cookie, csrf))
+        .header("X-CSRF-Token", &csrf)
         .json(&exercise)
         .send()
         .await
@@ -161,6 +213,8 @@ async fn test_exercise_and_note() {
     };
     let res = client
         .post(&format!("http://{}/note", addr))
+        .header("Cookie", format!("__Host-session={}; __Host-csrf={}", session_cookie, csrf))
+        .header("X-CSRF-Token", &csrf)
         .json(&note)
         .send()
         .await

--- a/sleep-api/tests/auth_csrf.rs
+++ b/sleep-api/tests/auth_csrf.rs
@@ -1,0 +1,151 @@
+use reqwest::Client;
+use sleep_api::{app, db};
+use argon2::{password_hash::{PasswordHasher, SaltString}, Argon2};
+use sleep_api::models::{Quality, SleepInput};
+use tokio::time::{sleep, Duration};
+
+fn set_admin_env(email: &str, password: &str) {
+    // Generate an argon2id hash for the given password and set envs
+    let salt = SaltString::generate(rand::rngs::OsRng);
+    let argon2 = Argon2::default();
+    let hash = argon2.hash_password(password.as_bytes(), &salt).unwrap().to_string();
+    unsafe {
+        std::env::set_var("ADMIN_EMAIL", email);
+        std::env::set_var("ADMIN_PASSWORD_HASH", hash);
+    }
+}
+
+async fn wait_ready(client: &Client, addr: &str) {
+    let health_url = format!("http://{}/health", addr);
+    for _ in 0..20 {
+        if client.get(&health_url).send().await.is_ok() {
+            return;
+        }
+        sleep(Duration::from_millis(100)).await;
+    }
+    panic!("server did not become ready");
+}
+
+fn parse_cookie<'a>(headers: impl Iterator<Item = &'a reqwest::header::HeaderValue>, name: &str) -> Option<String> {
+    for hv in headers {
+        if let Ok(s) = hv.to_str() {
+            // Set-Cookie can look like: "__Host-csrf=BASE64; Path=/; Secure; SameSite=Lax"
+            if s.starts_with(name) {
+                // extract value between name= and next ; or end
+                if let Some(eq_idx) = s.find('=') {
+                    let rest = &s[eq_idx + 1..];
+                    let end = rest.find(';').unwrap_or(rest.len());
+                    return Some(rest[..end].to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
+#[tokio::test]
+async fn test_auth_and_csrf_flow() {
+    // Env & DB
+    unsafe { std::env::set_var("DATABASE_URL", "sqlite::memory:") };
+    set_admin_env("admin@example.com", "password123");
+
+    let pool = db::connect().await.unwrap();
+    sqlx::migrate::Migrator::new(std::path::Path::new("../migrations"))
+        .await
+        .unwrap()
+        .run(&pool)
+        .await
+        .unwrap();
+
+    // Start server
+    let app = app::router(pool.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let _server = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    // Client with cookie store
+    let client = reqwest::Client::builder()
+        .cookie_store(true)
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+
+    wait_ready(&client, &addr.to_string()).await;
+
+    // Unauthed UI route should redirect to /login
+    let res = client
+        .get(&format!("http://{}/trends", addr))
+        .send()
+        .await
+        .unwrap();
+    assert!(res.status().is_redirection(), "expected redirect status, got {}", res.status());
+    let loc = res.headers().get(reqwest::header::LOCATION).unwrap().to_str().unwrap();
+    assert!(loc.ends_with("/login"), "expected redirect to /login, got {}", loc);
+
+    // Login with JSON
+    let login_body = serde_json::json!({
+        "email": "admin@example.com",
+        "password": "password123"
+    });
+    let res = client
+        .post(&format!("http://{}/login", addr))
+        .json(&login_body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    // Extract CSRF and session cookies from Set-Cookie headers
+    let csrf = parse_cookie(res.headers().get_all(reqwest::header::SET_COOKIE).iter(), "__Host-csrf=")
+        .expect("missing __Host-csrf cookie in login response");
+    let session = parse_cookie(res.headers().get_all(reqwest::header::SET_COOKIE).iter(), "__Host-session=")
+        .expect("missing __Host-session cookie in login response");
+
+    // Mutating API without CSRF header should be 403
+    let sample = SleepInput {
+        date: chrono::NaiveDate::from_ymd_opt(2025, 6, 17).unwrap(),
+        bed_time: chrono::NaiveTime::from_hms_opt(23, 5, 0).unwrap(),
+        wake_time: chrono::NaiveTime::from_hms_opt(6, 30, 0).unwrap(),
+        latency_min: 15,
+        awakenings: 0,
+        quality: Quality(4),
+    };
+    let res = client
+        .post(&format!("http://{}/sleep", addr))
+        .json(&sample)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 403, "posting without X-CSRF-Token must be 403");
+
+    // Mutating API with CSRF header should succeed
+    let res = client
+        .post(&format!("http://{}/sleep", addr))
+        .header("Cookie", format!("__Host-session={}; __Host-csrf={}", session, csrf))
+        .header("X-CSRF-Token", &csrf)
+        .json(&sample)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 201, "posting with matching CSRF should succeed");
+    let v: serde_json::Value = res.json().await.unwrap();
+    let id = v["id"].as_i64().unwrap();
+
+    // Logout clears session; subsequent mutating should be 401
+    let res = client
+        .post(&format!("http://{}/logout", addr))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 204);
+
+    let res = client
+        .delete(&format!("http://{}/sleep/{}", addr, id))
+        .header("X-CSRF-Token", &csrf)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 401, "after logout, mutating should be unauthorized");
+}

--- a/sleep-api/tests/auth_csrf.rs
+++ b/sleep-api/tests/auth_csrf.rs
@@ -1,14 +1,20 @@
+use argon2::{
+    Argon2,
+    password_hash::{PasswordHasher, SaltString},
+};
 use reqwest::Client;
-use sleep_api::{app, db};
-use argon2::{password_hash::{PasswordHasher, SaltString}, Argon2};
 use sleep_api::models::{Quality, SleepInput};
-use tokio::time::{sleep, Duration};
+use sleep_api::{app, db};
+use tokio::time::{Duration, sleep};
 
 fn set_admin_env(email: &str, password: &str) {
     // Generate an argon2id hash for the given password and set envs
     let salt = SaltString::generate(rand::rngs::OsRng);
     let argon2 = Argon2::default();
-    let hash = argon2.hash_password(password.as_bytes(), &salt).unwrap().to_string();
+    let hash = argon2
+        .hash_password(password.as_bytes(), &salt)
+        .unwrap()
+        .to_string();
     unsafe {
         std::env::set_var("ADMIN_EMAIL", email);
         std::env::set_var("ADMIN_PASSWORD_HASH", hash);
@@ -26,7 +32,10 @@ async fn wait_ready(client: &Client, addr: &str) {
     panic!("server did not become ready");
 }
 
-fn parse_cookie<'a>(headers: impl Iterator<Item = &'a reqwest::header::HeaderValue>, name: &str) -> Option<String> {
+fn parse_cookie<'a>(
+    headers: impl Iterator<Item = &'a reqwest::header::HeaderValue>,
+    name: &str,
+) -> Option<String> {
     for hv in headers {
         if let Ok(s) = hv.to_str() {
             // Set-Cookie can look like: "__Host-csrf=BASE64; Path=/; Secure; SameSite=Lax"
@@ -80,9 +89,22 @@ async fn test_auth_and_csrf_flow() {
         .send()
         .await
         .unwrap();
-    assert!(res.status().is_redirection(), "expected redirect status, got {}", res.status());
-    let loc = res.headers().get(reqwest::header::LOCATION).unwrap().to_str().unwrap();
-    assert!(loc.ends_with("/login"), "expected redirect to /login, got {}", loc);
+    assert!(
+        res.status().is_redirection(),
+        "expected redirect status, got {}",
+        res.status()
+    );
+    let loc = res
+        .headers()
+        .get(reqwest::header::LOCATION)
+        .unwrap()
+        .to_str()
+        .unwrap();
+    assert!(
+        loc.ends_with("/login"),
+        "expected redirect to /login, got {}",
+        loc
+    );
 
     // Login with JSON
     let login_body = serde_json::json!({
@@ -98,10 +120,16 @@ async fn test_auth_and_csrf_flow() {
     assert_eq!(res.status(), 200);
 
     // Extract CSRF and session cookies from Set-Cookie headers
-    let csrf = parse_cookie(res.headers().get_all(reqwest::header::SET_COOKIE).iter(), "__Host-csrf=")
-        .expect("missing __Host-csrf cookie in login response");
-    let session = parse_cookie(res.headers().get_all(reqwest::header::SET_COOKIE).iter(), "__Host-session=")
-        .expect("missing __Host-session cookie in login response");
+    let csrf = parse_cookie(
+        res.headers().get_all(reqwest::header::SET_COOKIE).iter(),
+        "__Host-csrf=",
+    )
+    .expect("missing __Host-csrf cookie in login response");
+    let session = parse_cookie(
+        res.headers().get_all(reqwest::header::SET_COOKIE).iter(),
+        "__Host-session=",
+    )
+    .expect("missing __Host-session cookie in login response");
 
     // Mutating API without CSRF header should be 403
     let sample = SleepInput {
@@ -118,18 +146,29 @@ async fn test_auth_and_csrf_flow() {
         .send()
         .await
         .unwrap();
-    assert_eq!(res.status(), 403, "posting without X-CSRF-Token must be 403");
+    assert_eq!(
+        res.status(),
+        403,
+        "posting without X-CSRF-Token must be 403"
+    );
 
     // Mutating API with CSRF header should succeed
     let res = client
         .post(&format!("http://{}/sleep", addr))
-        .header("Cookie", format!("__Host-session={}; __Host-csrf={}", session, csrf))
+        .header(
+            "Cookie",
+            format!("__Host-session={}; __Host-csrf={}", session, csrf),
+        )
         .header("X-CSRF-Token", &csrf)
         .json(&sample)
         .send()
         .await
         .unwrap();
-    assert_eq!(res.status(), 201, "posting with matching CSRF should succeed");
+    assert_eq!(
+        res.status(),
+        201,
+        "posting with matching CSRF should succeed"
+    );
     let v: serde_json::Value = res.json().await.unwrap();
     let id = v["id"].as_i64().unwrap();
 
@@ -147,5 +186,9 @@ async fn test_auth_and_csrf_flow() {
         .send()
         .await
         .unwrap();
-    assert_eq!(res.status(), 401, "after logout, mutating should be unauthorized");
+    assert_eq!(
+        res.status(),
+        401,
+        "after logout, mutating should be unauthorized"
+    );
 }


### PR DESCRIPTION
Summary

This PR implements PR-A: single-user session authentication, double-submit CSRF protection, and security headers for the Axum backend. It protects the /trends UI route and all mutating API routes, while keeping non‑mutating GET routes open.

Key changes

- Auth
  - Added /login (GET/POST) and /logout endpoints
  - Encrypted + signed session cookie __Host-session (Secure, HttpOnly, SameSite=Lax, Path=/) via axum-extra PrivateCookieJar
  - AppState introduced with Db + Key; FromRef implemented for Db and Key
  - RequireSessionJson (401 JSON on unauthenticated) and RequireSessionRedirect (302 to /login for UI)
- CSRF (double-submit)
  - Issued __Host-csrf cookie (Secure, SameSite=Lax, Path=/; not HttpOnly), URL‑safe base64 token
  - CsrfGuard verifies header X-CSRF-Token equals the cookie value (percent-decoding supported) for POST/PUT/DELETE
  - Same-site heuristic using Sec-Fetch-Site if present
- Security headers
  - X-Content-Type-Options: nosniff
  - X-Frame-Options: DENY
  - Referrer-Policy: strict-origin-when-cross-origin
  - Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'
  - Strict-Transport-Security when ENABLE_HSTS=1/true
- Route protection
  - /trends protected via RequireSessionRedirect
  - Mutating routes protected via RequireSessionJson + CsrfGuard:
    - POST /sleep, PUT /sleep/{id}, DELETE /sleep/{id}
    - POST /exercise, POST /note
  - Open routes remain: GET /health, GET /sleep/date/{date}, GET /api/trends/*
- Config and tooling
  - .env.example with ADMIN_EMAIL, ADMIN_PASSWORD_HASH, SESSION_SECRET, CSRF_SECRET placeholder, ENABLE_HSTS
  - session_key() derives Key from SESSION_SECRET or generates fallback
  - hsts_enabled() reads ENABLE_HSTS
  - pw-hash helper (cargo run -p sleep-api --bin pw-hash) to generate Argon2id hashes
- Documentation
  - Added module and item docs for auth, CSRF, headers, middleware extractors, AppState, config helpers, and pw-hash, with examples and references

Tests

- New: tests/auth_csrf.rs validates:
  - Unauth /trends redirects to /login
  - Login emits __Host-session and __Host-csrf
  - Mutating without CSRF → 403; with matching header + cookie → success
  - Logout → subsequent mutating returns 401
- Updated: tests/api_sleep.rs and tests/trends_bars.rs
  - Added login step, send Cookie (__Host‑session, __Host‑csrf) + X‑CSRF‑Token for mutating calls
  - Bound to 127.0.0.2 for isolation

Quality gates

- cargo clippy -- -D warnings passes
- cargo test -p sleep-api passes (unit, integration, doc tests)

Security & operational notes

- __Host- cookies require Secure and Path=/; browsers won’t persist over plain HTTP. Automated tests are unaffected. For local browser dev, use TLS (reverse proxy/local certs) or feature-gate for HTTP if necessary.
- Session is cookie-only; optional session expiry/idle timeouts can be added later.

Follow-ups (optional)

- Add session expiry/idle timeouts and login rate limiting
- Tighten CSP in a future PR (remove 'unsafe-inline', add nonces)
- Expand frontend UI for login
