### PR TITLE
🐛 Fix Docker login 500: point Vite proxy to API container via PROXY_TARGET

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -14,6 +14,8 @@ services:
     working_dir: /app
     ports:
       - "5173:5173"
+    environment:
+      - PROXY_TARGET=http://api:8080
     volumes:
       - ./sleep-ui:/app
       - /app/node_modules

--- a/sleep-ui/vite.config.ts
+++ b/sleep-ui/vite.config.ts
@@ -1,22 +1,23 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import tailwindcss from '@tailwindcss/vite';
 import { defineConfig } from 'vite';
+const target = process.env.PROXY_TARGET ?? 'http://localhost:8080';
 
 export default defineConfig({
   plugins: [tailwindcss(), sveltekit()],
   server: {
     port: 5173,
     proxy: {
-      '/api': { target: 'http://localhost:8080', changeOrigin: true },
+      '/api': { target, changeOrigin: true },
       '/auth': {
-        target: 'http://localhost:8080',
+        target,
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/auth/, '')
       },
-      '/sleep': { target: 'http://localhost:8080', changeOrigin: true },
-      '/exercise': { target: 'http://localhost:8080', changeOrigin: true },
-      '/note': { target: 'http://localhost:8080', changeOrigin: true },
-      '/health': { target: 'http://localhost:8080', changeOrigin: true }
+      '/sleep': { target, changeOrigin: true },
+      '/exercise': { target, changeOrigin: true },
+      '/note': { target, changeOrigin: true },
+      '/health': { target, changeOrigin: true }
     }
   }
 });


### PR DESCRIPTION
Root cause

- The UI container’s Vite dev proxy was targeting http://localhost:8080. Inside Docker, localhost points to the UI container itself, not the API container. As a result, proxying /login failed with ECONNREFUSED and Vite returned a 500.

What changed

- sleep-ui/vite.config.ts
  - Introduced an env-configurable proxy target:
    ```ts
    const target = process.env.PROXY_TARGET ?? 'http://localhost:8080';
    ```
  - All proxy entries now use target.
- compose.yaml (ui service)
  - Set PROXY_TARGET so Vite proxies to the API container on the compose network:
    ```yaml
    environment:
      - PROXY_TARGET=http://api:8080
    ```

Why this fixes it

- In Docker Compose, the API is reachable via the service hostname http://api:8080. Pointing Vite’s proxy at that host avoids ECONNREFUSED and eliminates the 500 on /login.

Testing

1) Ensure .env.docker contains valid values:
   - ADMIN_EMAIL
   - ADMIN_PASSWORD_HASH (argon2id string)
   - SESSION_SECRET (base64)
2) Rebuild and start:
   ```bash
   docker compose up --build
   ```
3) Open http://localhost:5173/login and sign in.
4) Verify /api/session reflects authentication and protected routes (/sleep, etc.) work.

Local Docker cookie considerations

- By default, the API sets Secure cookies (COOKIE_SECURE defaults to true). Over plain HTTP, browsers ignore Secure cookies, so sessions won’t persist.
- For local dev without TLS, set this in .env.docker (dev-only):
  ```dotenv
  COOKIE_SECURE=0
  ```
  Or keep Secure cookies and terminate TLS in front of the stack (e.g., Traefik/Nginx).

Files changed

- sleep-ui/vite.config.ts
- compose.yaml

Commits

- ui(vite): make proxy target configurable via PROXY_TARGET for Docker networking
- compose(ui): set PROXY_TARGET to http://api:8080 so Vite proxies to API container; resolves ECONNREFUSED 500 on /login in Docker